### PR TITLE
Ensure shims work properly when used with volta@0.6

### DIFF
--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -31,30 +31,42 @@ describe('buildLayout', () => {
   test('creates the rough folder structure', async () => {
     const tmpdir = await createTempDir();
 
+    tmpdir.write({
+      bin: {
+        shim: 'shim-file-here',
+      },
+    });
+
     await buildLayout(tmpdir.path());
 
     expect(tmpdir.read()).toMatchInlineSnapshot(`
-      Object {
-        "bin": Object {},
-        "cache": Object {
-          "node": Object {},
-        },
-        "log": Object {},
-        "tmp": Object {},
-        "tools": Object {
-          "image": Object {
-            "node": Object {},
-            "packages": Object {},
-            "yarn": Object {},
-          },
-          "inventory": Object {
-            "node": Object {},
-            "packages": Object {},
-            "yarn": Object {},
-          },
-          "user": Object {},
-        },
-      }
-    `);
+Object {
+  "bin": Object {
+    "node": "shim-file-here",
+    "npm": "shim-file-here",
+    "npx": "shim-file-here",
+    "shim": "shim-file-here",
+    "yarn": "shim-file-here",
+  },
+  "cache": Object {
+    "node": Object {},
+  },
+  "log": Object {},
+  "tmp": Object {},
+  "tools": Object {
+    "image": Object {
+      "node": Object {},
+      "packages": Object {},
+      "yarn": Object {},
+    },
+    "inventory": Object {
+      "node": Object {},
+      "packages": Object {},
+      "yarn": Object {},
+    },
+    "user": Object {},
+  },
+}
+`);
   });
 });


### PR DESCRIPTION
When using volta@0.6.3 the shims must be manually setup (symlinked) from the `$VOLTA_HOME/bin/shim` path to each of `$VOLTA_HOME/bin/{node,yarn,npx,npm}`. The changes landed in db6be2dc54f were a bit over eager in removing this.

This regression was caught while working on stricter test harness in #19.