### PR TITLE
Update `tsc` matcher to associate failure with correct line/column.

### DIFF
--- a/matchers/tsc.json
+++ b/matchers/tsc.json
@@ -4,12 +4,13 @@
             "owner": "tsc",
             "pattern": [
                 {
-                    "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+|\\d+,\\d+|\\d+,\\d+,\\d+,\\d+)\\)\\s*:\\s+(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
+                    "regexp": "^([^\\s].*)[\\(:](\\d+)[,:](\\d+)(?:\\):\\s+|\\s+-\\s+)(error|warning|info)\\s+TS(\\d+)\\s*:\\s*(.*)$",
                     "file": 1,
-                    "location": 2,
-                    "severity": 3,
-                    "code": 4,
-                    "message": 5
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "code": 5,
+                    "message": 6
                 }
             ]
         }


### PR DESCRIPTION
Updates `tsc` matcher to properly capture the line / column information. 

This mirrors the changes made in https://github.com/actions/setup-node/pull/125 (which was released in https://github.com/actions/setup-node/releases/tag/v2.1.5).
