### PR TITLE
Update action metadata to leverage Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ branding:
   icon: 'zap'
   color: 'yellow'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
I'm not 100% sure that this is actually breaking, but it seems plausibly breaking to folks using custom runners?
