### PR TITLE
Add `scope` to list of inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,8 @@ inputs:
     default: ''
   registry-url:
     description: 'Optional registry to set up for auth. Will set the registry in a project level .npmrc file, and set up auth to read in from env.NODE_AUTH_TOKEN'
+  scope:
+    description: 'Optional scope for authenticating against scoped registries. Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/).'
   always-auth:
     description: 'Set always-auth in npmrc'
     default: 'false'


### PR DESCRIPTION
The usage of `scope` was added in #64, but we missed adding this entry in the `action.yml`.

Fixes #94 
