### PR TITLE
Use `${{ github.token }}` to authenticate tool cache downloads

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
     description: 'Optional registry to set up for auth. Will set the registry in a project level .npmrc file, and set up auth to read in from env.NODE_AUTH_TOKEN'
   scope:
     description: 'Optional scope for authenticating against scoped registries. Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/).'
+  token:
+    description: Used to avoid low rate limiting for cached tool downloads.  Since there's a default, this is typically not supplied by the user.
+    default: ${{ github.token }}
   always-auth:
     description: 'Set always-auth in npmrc'
     default: 'false'

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "license": "MIT",
   "author": "Robert Jackson <me@rwjblue.com>",
+  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "build": "npm-run-all build:clean build:ts build:dist",
@@ -25,13 +26,11 @@
     "lint:types": "tsc --noEmit",
     "test": "jest"
   },
-  "type": "module",
-  "dependencies": {
-    "@actions/github": "^5.0.3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@actions/core": "^1.9.1",
     "@actions/exec": "^1.1.1",
+    "@actions/github": "^5.0.3",
     "@actions/glob": "^0.3.0",
     "@actions/io": "^1.1.2",
     "@actions/tool-cache": "^2.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,10 @@ import addMatchers from './matchers';
 
 async function run(): Promise<void> {
   try {
+    const authToken = core.getInput('token', { required: false });
     const voltaVersion = core.getInput('volta-version', { required: false });
 
-    await installer.getVolta(voltaVersion);
+    await installer.getVolta(voltaVersion, authToken);
 
     const hasPackageJSON = await findUp('package.json');
     const nodeVersion = core.getInput('node-version', { required: false });


### PR DESCRIPTION
Thread through `${{ github.token }}` in order to use it with `@actions/tool-cache` to avoid rate limiting (rate limits for anon users are much lower than for authenticated ones).

First step working on aiding https://github.com/volta-cli/action/issues/77.