### PR TITLE
Adding optional input for openssl-version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   yarn-version:
     description: 'Version Spec of the yarn version to use.  Examples: 1.6.x, 10.15.1, >=10.15.0'
     default: ''
+  openssl-version:
+    description: 'Version Spec of the openssl version to use.  Examples: 1.0, 1.1'
+    default: ''
   registry-url:
     description: 'Optional registry to set up for auth. Will set the registry in a project level .npmrc file, and set up auth to read in from env.NODE_AUTH_TOKEN'
   scope:

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,9 @@ async function run(): Promise<void> {
   try {
     const authToken = core.getInput('token', { required: false });
     const voltaVersion = core.getInput('volta-version', { required: false });
+    const openSSLVersion = core.getInput('openssl-version', { required: false });
 
-    await installer.getVolta(voltaVersion, authToken);
+    await installer.getVolta(voltaVersion, authToken, openSSLVersion);
 
     const hasPackageJSON = await findUp('package.json');
     const nodeVersion = core.getInput('node-version', { required: false });

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -23,6 +23,16 @@ describe('buildDownloadUrl', () => {
     );
   });
 
+  test('linux with openssl-version input', async function () {
+    expect(await buildDownloadUrl('linux', '0.6.4', '1.0')).toMatchInlineSnapshot(
+      `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.0.tar.gz"`
+    );
+
+    expect(await buildDownloadUrl('linux', '0.6.4', '1.1')).toMatchInlineSnapshot(
+      `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.1.tar.gz"`
+    );
+  });
+
   test('win32', async function () {
     expect(await buildDownloadUrl('win32', '0.7.2')).toMatchInlineSnapshot(
       `"https://github.com/volta-cli/volta/releases/download/v0.7.2/volta-0.7.2-windows-x86_64.msi"`

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -65,22 +65,28 @@ async function execOpenSSLVersion() {
 }
 
 async function getOpenSSLVersion(version = ''): Promise<string> {
-  if (version === '') {
-    version = await execOpenSSLVersion();
-  }
+  const specificVersionViaInput = /^\d{1,3}\.\d{1,3}$/.test(version);
 
-  // typical version string looks like 'OpenSSL 1.0.1e-fips 11 Feb 2013'
-  const openSSLVersionPattern = /^([^\s]*)\s([0-9]+\.[0-9]+)/;
-  const match = openSSLVersionPattern.exec(version);
+  if (!specificVersionViaInput) {
+    if (version === '') {
+      version = await execOpenSSLVersion();
+    }
 
-  if (match === null) {
-    throw new Error(
-      `No version of OpenSSL was found. @volta-cli/action requires a valid version of OpenSSL. ('openssl version' output: ${version})`
-    );
+    // typical version string looks like 'OpenSSL 1.0.1e-fips 11 Feb 2013'
+    const openSSLVersionPattern = /^([^\s]*)\s([0-9]+\.[0-9]+)/;
+    const match = openSSLVersionPattern.exec(version);
+
+    if (match === null) {
+      throw new Error(
+        `No version of OpenSSL was found. @volta-cli/action requires a valid version of OpenSSL. ('openssl version' output: ${version})`
+      );
+    }
+
+    version = match[2];
   }
 
   // should return in openssl-1.1 format
-  return `openssl-${match[2]}`;
+  return `openssl-${version}`;
 }
 
 /*
@@ -131,14 +137,18 @@ export async function buildLayout(voltaHome: string): Promise<void> {
   await setupShims(voltaHome);
 }
 
-async function acquireVolta(version: string, authToken: string): Promise<string> {
+async function acquireVolta(
+  version: string,
+  authToken: string,
+  openSSLVersion: string
+): Promise<string> {
   //
   // Download - a tool installer intimately knows how to get the tool (and construct urls)
   //
 
   core.info(`downloading volta@${version}`);
 
-  const downloadUrl = await buildDownloadUrl(os.platform(), version);
+  const downloadUrl = await buildDownloadUrl(os.platform(), version, openSSLVersion);
 
   core.debug(`downloading from \`${downloadUrl}\``);
   const downloadPath = await tc.downloadTool(downloadUrl, undefined, authToken);
@@ -252,14 +262,18 @@ export async function getVoltaVersion(versionSpec: string): Promise<string> {
   return version;
 }
 
-export async function getVolta(versionSpec: string, authToken: string): Promise<void> {
+export async function getVolta(
+  versionSpec: string,
+  authToken: string,
+  openSSLVersion: string
+): Promise<void> {
   const version = await getVoltaVersion(versionSpec);
 
   let voltaHome = tc.find('volta', version);
 
   if (voltaHome === '') {
     // download, extract, cache
-    const toolRoot = await acquireVolta(version, authToken);
+    const toolRoot = await acquireVolta(version, authToken, openSSLVersion);
 
     await setupVolta(version, toolRoot);
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -67,23 +67,25 @@ async function execOpenSSLVersion() {
 async function getOpenSSLVersion(version = ''): Promise<string> {
   const specificVersionViaInput = /^\d{1,3}\.\d{1,3}$/.test(version);
 
-  if (!specificVersionViaInput) {
-    if (version === '') {
-      version = await execOpenSSLVersion();
-    }
-
-    // typical version string looks like 'OpenSSL 1.0.1e-fips 11 Feb 2013'
-    const openSSLVersionPattern = /^([^\s]*)\s([0-9]+\.[0-9]+)/;
-    const match = openSSLVersionPattern.exec(version);
-
-    if (match === null) {
-      throw new Error(
-        `No version of OpenSSL was found. @volta-cli/action requires a valid version of OpenSSL. ('openssl version' output: ${version})`
-      );
-    }
-
-    version = match[2];
+  if (specificVersionViaInput) {
+    return `openssl-${version}`;
   }
+
+  if (version === '') {
+    version = await execOpenSSLVersion();
+  }
+
+  // typical version string looks like 'OpenSSL 1.0.1e-fips 11 Feb 2013'
+  const openSSLVersionPattern = /^([^\s]*)\s([0-9]+\.[0-9]+)/;
+  const match = openSSLVersionPattern.exec(version);
+
+  if (match === null) {
+    throw new Error(
+      `No version of OpenSSL was found. @volta-cli/action requires a valid version of OpenSSL. ('openssl version' output: ${version})`
+    );
+  }
+
+  version = match[2];
 
   // should return in openssl-1.1 format
   return `openssl-${version}`;


### PR DESCRIPTION
In self-hosted GitHub environments, it's possible that `openssl` isn't on the machine's path, thus causing the setup to fail when trying to discover the version of openssl using `openssl version`. 

This change adds support for an `openssl-version` input, which allows us to bypass the version check and specify the version on the machine explicitly. While this is less dynamic and portable, it can be used in narrow circumstances.