### PR TITLE
Remove reference to https://volta.sh/latest-version in logging

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -273,7 +273,7 @@ export async function getVoltaVersion(versionSpec: string, authToken: string): P
   if (validVersionProvided) {
     core.info(`using user provided version volta@${version}`);
   } else {
-    core.info(`looking up latest volta version from https://volta.sh/latest-version`);
+    core.info(`looking up latest volta version`);
     version = await getLatestVolta(authToken);
   }
 


### PR DESCRIPTION
We no longer use `volta.sh/latest-version` (we use GH API instead), but
this log message wasn't updated when we made that swap.
