### PR TITLE
Update link to Volta releases page

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ steps:
 - run: yarn test
 ```
 
-The `variant` fragment corresponds to a portion of the installer filename, and can be found in the [Volta Releases](https://github.com/volta-cli/action/releases) page.
+The `variant` fragment corresponds to a portion of the installer filename, and can be found in the [Volta Releases](https://github.com/volta-cli/volta/releases) page.
 
 ## License
 


### PR DESCRIPTION
The documentation in the README about the `variant` input mentions that the value should match a portion of the installer name on the _volta_ releases page, but the link went to the releases for the action itself, which doesn't seem like the intension of the docs.