### PR TITLE
[BACKPORT] Add volta@1.1.0 support to v3.x releases.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        volta-version: ["1.0.0", "1.0.8"]
+        volta-version: ["1.0.0", "1.0.8", "1.1.0"]
         os: [ubuntu, macOS, windows]
 
     steps:

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -3,46 +3,110 @@ import { createTempDir } from 'broccoli-test-helper';
 import nock from 'nock';
 
 describe('buildDownloadUrl', () => {
-  test('darwin', async function () {
-    expect(await buildDownloadUrl('darwin', '0.6.4')).toMatchInlineSnapshot(
-      `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-macos.tar.gz"`
-    );
+  describe('volta < 1.1.0', function () {
+    test('darwin - x64', async function () {
+      expect(await buildDownloadUrl('darwin', 'x64', '0.6.4')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-macos.tar.gz"`
+      );
+    });
+
+    test('darwin - arm64', async function () {
+      expect(await buildDownloadUrl('darwin', 'arm64', '0.6.4')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-macos.tar.gz"`
+      );
+    });
+
+    test('linux', async function () {
+      expect(
+        await buildDownloadUrl('linux', 'x64', '0.6.4', 'OpenSSL 1.0.1e-fips 11 Feb 2013')
+      ).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.0.tar.gz"`
+      );
+
+      expect(
+        await buildDownloadUrl('linux', 'x64', '0.6.4', 'OpenSSL 1.1.1e-fips 11 Sep 2018')
+      ).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.1.tar.gz"`
+      );
+    });
+
+    test('linux with openssl-version input', async function () {
+      expect(await buildDownloadUrl('linux', 'x64', '0.6.4', '1.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.0.tar.gz"`
+      );
+
+      expect(await buildDownloadUrl('linux', 'x64', '0.6.4', '1.1')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.1.tar.gz"`
+      );
+    });
+
+    test('win32', async function () {
+      expect(await buildDownloadUrl('win32', 'x86-64', '0.7.2')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.7.2/volta-0.7.2-windows-x86_64.msi"`
+      );
+    });
+
+    test('aix', async function () {
+      expect(
+        async () =>
+          await buildDownloadUrl('aix', 'hmm, wat?? (I dont know a valid arch for aix)', '0.6.4')
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"your platform aix is not yet supported"`);
+    });
   });
 
-  test('linux', async function () {
-    expect(
-      await buildDownloadUrl('linux', '0.6.4', 'OpenSSL 1.0.1e-fips 11 Feb 2013')
-    ).toMatchInlineSnapshot(
-      `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.0.tar.gz"`
-    );
+  describe('volta@1.1.0', function () {
+    test('darwin - x64', async function () {
+      expect(await buildDownloadUrl('darwin', 'x64', '1.1.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-macos.tar.gz"`
+      );
+    });
 
-    expect(
-      await buildDownloadUrl('linux', '0.6.4', 'OpenSSL 1.1.1e-fips 11 Sep 2018')
-    ).toMatchInlineSnapshot(
-      `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.1.tar.gz"`
-    );
-  });
+    test('darwin - arm64', async function () {
+      expect(await buildDownloadUrl('darwin', 'arm64', '1.1.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-macos-aarch64.tar.gz"`
+      );
+    });
 
-  test('linux with openssl-version input', async function () {
-    expect(await buildDownloadUrl('linux', '0.6.4', '1.0')).toMatchInlineSnapshot(
-      `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.0.tar.gz"`
-    );
+    test('linux', async function () {
+      expect(
+        await buildDownloadUrl('linux', 'x64', '1.1.0', 'OpenSSL 1.0.1e-fips 11 Feb 2013')
+      ).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-linux.tar.gz"`
+      );
 
-    expect(await buildDownloadUrl('linux', '0.6.4', '1.1')).toMatchInlineSnapshot(
-      `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.1.tar.gz"`
-    );
-  });
+      expect(
+        await buildDownloadUrl('linux', 'x64', '1.1.0', 'OpenSSL 1.1.1e-fips 11 Sep 2018')
+      ).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-linux.tar.gz"`
+      );
 
-  test('win32', async function () {
-    expect(await buildDownloadUrl('win32', '0.7.2')).toMatchInlineSnapshot(
-      `"https://github.com/volta-cli/volta/releases/download/v0.7.2/volta-0.7.2-windows-x86_64.msi"`
-    );
-  });
+      expect(await buildDownloadUrl('linux', 'x64', '1.1.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-linux.tar.gz"`
+      );
+    });
 
-  test('aix', async function () {
-    expect(
-      async () => await buildDownloadUrl('aix', '0.6.4')
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"your platform aix is not yet supported"`);
+    test('linux with openssl-version input', async function () {
+      expect(await buildDownloadUrl('linux', 'x64', '1.1.0', '1.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-linux.tar.gz"`
+      );
+
+      expect(await buildDownloadUrl('linux', 'x64', '1.1.0', '1.1')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-linux.tar.gz"`
+      );
+    });
+
+    test('win32', async function () {
+      expect(await buildDownloadUrl('win32', 'x86-64', '1.1.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-windows-x86_64.msi"`
+      );
+    });
+
+    test('aix', async function () {
+      expect(
+        async () =>
+          await buildDownloadUrl('aix', 'hmm, wat?? (I dont know a valid arch for aix)', '1.1.0')
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"your platform aix is not yet supported"`);
+    });
   });
 });
 
@@ -59,34 +123,34 @@ describe('buildLayout', () => {
     await buildLayout(tmpdir.path());
 
     expect(tmpdir.read()).toMatchInlineSnapshot(`
-Object {
-  "bin": Object {
-    "node": "shim-file-here",
-    "npm": "shim-file-here",
-    "npx": "shim-file-here",
-    "shim": "shim-file-here",
-    "yarn": "shim-file-here",
-  },
-  "cache": Object {
-    "node": Object {},
-  },
-  "log": Object {},
-  "tmp": Object {},
-  "tools": Object {
-    "image": Object {
-      "node": Object {},
-      "packages": Object {},
-      "yarn": Object {},
-    },
-    "inventory": Object {
-      "node": Object {},
-      "packages": Object {},
-      "yarn": Object {},
-    },
-    "user": Object {},
-  },
-}
-`);
+      Object {
+        "bin": Object {
+          "node": "shim-file-here",
+          "npm": "shim-file-here",
+          "npx": "shim-file-here",
+          "shim": "shim-file-here",
+          "yarn": "shim-file-here",
+        },
+        "cache": Object {
+          "node": Object {},
+        },
+        "log": Object {},
+        "tmp": Object {},
+        "tools": Object {
+          "image": Object {
+            "node": Object {},
+            "packages": Object {},
+            "yarn": Object {},
+          },
+          "inventory": Object {
+            "node": Object {},
+            "packages": Object {},
+            "yarn": Object {},
+          },
+          "user": Object {},
+        },
+      }
+    `);
   });
 });
 


### PR DESCRIPTION
Backport changes from #115 to add volta@1.1.0 support to the v3 branch.

Address #117 for v3.