### PR TITLE
[BACKPORT] Add volta@1.1.0 support to v2.x release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        volta-version: ["0.9.0","0.8.7","0.7.2","0.6.8"]
+        volta-version: ["0.9.0","0.8.7","0.7.2","0.6.8", "1.1.0"]
         os: [ubuntu, macOS, windows]
         exclude:
           # this action didn't support windows until at least Volta 0.7

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -2,36 +2,90 @@ import { buildLayout, buildDownloadUrl } from './installer';
 import { createTempDir } from 'broccoli-test-helper';
 
 describe('buildDownloadUrl', () => {
-  test('darwin', async function () {
-    expect(await buildDownloadUrl('darwin', '0.6.4')).toMatchInlineSnapshot(
-      `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-macos.tar.gz"`
-    );
+  describe('volta < 1.1.0', function () {
+    test('darwin - x64', async function () {
+      expect(await buildDownloadUrl('darwin', 'x64', '0.6.4')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-macos.tar.gz"`
+      );
+    });
+
+    test('darwin - arm64', async function () {
+      expect(await buildDownloadUrl('darwin', 'arm64', '0.6.4')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-macos.tar.gz"`
+      );
+    });
+
+    test('linux', async function () {
+      expect(
+        await buildDownloadUrl('linux', 'x64', '0.6.4', 'OpenSSL 1.0.1e-fips 11 Feb 2013')
+      ).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.0.tar.gz"`
+      );
+
+      expect(
+        await buildDownloadUrl('linux', 'x64', '0.6.4', 'OpenSSL 1.1.1e-fips 11 Sep 2018')
+      ).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.1.tar.gz"`
+      );
+    });
+
+    test('win32', async function () {
+      expect(await buildDownloadUrl('win32', 'x86-64', '0.7.2')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v0.7.2/volta-0.7.2-windows-x86_64.msi"`
+      );
+    });
+
+    test('aix', async function () {
+      expect(
+        async () =>
+          await buildDownloadUrl('aix', 'hmm, wat?? (I dont know a valid arch for aix)', '0.6.4')
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"your platform aix is not yet supported"`);
+    });
   });
 
-  test('linux', async function () {
-    expect(
-      await buildDownloadUrl('linux', '0.6.4', 'OpenSSL 1.0.1e-fips 11 Feb 2013')
-    ).toMatchInlineSnapshot(
-      `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.0.tar.gz"`
-    );
+  describe('volta@1.1.0', function () {
+    test('darwin - x64', async function () {
+      expect(await buildDownloadUrl('darwin', 'x64', '1.1.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-macos.tar.gz"`
+      );
+    });
 
-    expect(
-      await buildDownloadUrl('linux', '0.6.4', 'OpenSSL 1.1.1e-fips 11 Sep 2018')
-    ).toMatchInlineSnapshot(
-      `"https://github.com/volta-cli/volta/releases/download/v0.6.4/volta-0.6.4-linux-openssl-1.1.tar.gz"`
-    );
-  });
+    test('darwin - arm64', async function () {
+      expect(await buildDownloadUrl('darwin', 'arm64', '1.1.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-macos-aarch64.tar.gz"`
+      );
+    });
 
-  test('win32', async function () {
-    expect(await buildDownloadUrl('win32', '0.7.2')).toMatchInlineSnapshot(
-      `"https://github.com/volta-cli/volta/releases/download/v0.7.2/volta-0.7.2-windows-x86_64.msi"`
-    );
-  });
+    test('linux', async function () {
+      expect(
+        await buildDownloadUrl('linux', 'x64', '1.1.0', 'OpenSSL 1.0.1e-fips 11 Feb 2013')
+      ).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-linux.tar.gz"`
+      );
 
-  test('aix', async function () {
-    expect(
-      async () => await buildDownloadUrl('aix', '0.6.4')
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"your platform aix is not yet supported"`);
+      expect(
+        await buildDownloadUrl('linux', 'x64', '1.1.0', 'OpenSSL 1.1.1e-fips 11 Sep 2018')
+      ).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-linux.tar.gz"`
+      );
+
+      expect(await buildDownloadUrl('linux', 'x64', '1.1.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-linux.tar.gz"`
+      );
+    });
+
+    test('win32', async function () {
+      expect(await buildDownloadUrl('win32', 'x86-64', '1.1.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-windows-x86_64.msi"`
+      );
+    });
+
+    test('aix', async function () {
+      expect(
+        async () =>
+          await buildDownloadUrl('aix', 'hmm, wat?? (I dont know a valid arch for aix)', '1.1.0')
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"your platform aix is not yet supported"`);
+    });
   });
 });
 
@@ -48,33 +102,33 @@ describe('buildLayout', () => {
     await buildLayout(tmpdir.path());
 
     expect(tmpdir.read()).toMatchInlineSnapshot(`
-Object {
-  "bin": Object {
-    "node": "shim-file-here",
-    "npm": "shim-file-here",
-    "npx": "shim-file-here",
-    "shim": "shim-file-here",
-    "yarn": "shim-file-here",
-  },
-  "cache": Object {
-    "node": Object {},
-  },
-  "log": Object {},
-  "tmp": Object {},
-  "tools": Object {
-    "image": Object {
-      "node": Object {},
-      "packages": Object {},
-      "yarn": Object {},
-    },
-    "inventory": Object {
-      "node": Object {},
-      "packages": Object {},
-      "yarn": Object {},
-    },
-    "user": Object {},
-  },
-}
-`);
+      Object {
+        "bin": Object {
+          "node": "shim-file-here",
+          "npm": "shim-file-here",
+          "npx": "shim-file-here",
+          "shim": "shim-file-here",
+          "yarn": "shim-file-here",
+        },
+        "cache": Object {
+          "node": Object {},
+        },
+        "log": Object {},
+        "tmp": Object {},
+        "tools": Object {
+          "image": Object {
+            "node": Object {},
+            "packages": Object {},
+            "yarn": Object {},
+          },
+          "inventory": Object {
+            "node": Object {},
+            "packages": Object {},
+            "yarn": Object {},
+          },
+          "user": Object {},
+        },
+      }
+    `);
   });
 });

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -23,25 +23,46 @@ function voltaVersionHasSetup(version: string): boolean {
 
 export async function buildDownloadUrl(
   platform: string,
+  arch: string,
   version: string,
   openSSLVersion = ''
 ): Promise<string> {
   let fileName: string;
-  switch (platform) {
-    case 'darwin':
-      fileName = `volta-${version}-macos.tar.gz`;
-      break;
-    case 'linux': {
-      openSSLVersion = await getOpenSSLVersion(openSSLVersion);
 
-      fileName = `volta-${version}-linux-${openSSLVersion}.tar.gz`;
-      break;
+  const isOpenSSLDependent = semver.lt(version, '1.1.0');
+
+  if (isOpenSSLDependent) {
+    switch (platform) {
+      case 'darwin':
+        fileName = `volta-${version}-macos.tar.gz`;
+        break;
+      case 'linux': {
+        openSSLVersion = await getOpenSSLVersion(openSSLVersion);
+
+        fileName = `volta-${version}-linux-${openSSLVersion}.tar.gz`;
+        break;
+      }
+      case 'win32':
+        fileName = `volta-${version}-windows-x86_64.msi`;
+        break;
+      default:
+        throw new Error(`your platform ${platform} is not yet supported`);
     }
-    case 'win32':
-      fileName = `volta-${version}-windows-x86_64.msi`;
-      break;
-    default:
-      throw new Error(`your platform ${platform} is not yet supported`);
+  } else {
+    switch (platform) {
+      case 'darwin':
+        fileName = `volta-${version}-macos${arch === 'arm64' ? '-aarch64' : ''}.tar.gz`;
+        break;
+      case 'linux': {
+        fileName = `volta-${version}-linux.tar.gz`;
+        break;
+      }
+      case 'win32':
+        fileName = `volta-${version}-windows-x86_64.msi`;
+        break;
+      default:
+        throw new Error(`your platform ${platform} is not yet supported`);
+    }
   }
 
   return `https://github.com/volta-cli/volta/releases/download/v${version}/${fileName}`;
@@ -138,7 +159,7 @@ async function acquireVolta(version: string): Promise<string> {
 
   core.info(`downloading volta@${version}`);
 
-  const downloadUrl = await buildDownloadUrl(os.platform(), version);
+  const downloadUrl = await buildDownloadUrl(os.platform(), os.arch(), version);
 
   core.debug(`downloading from \`${downloadUrl}\``);
   const downloadPath = await tc.downloadTool(downloadUrl);


### PR DESCRIPTION
Backport changes from #115 (that are applicable) to v2.x releases.
