### PR TITLE
Update download url to support new architectures for Volta 2.0.0

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -23137,6 +23137,7 @@ function voltaVersionHasSetup(version) {
 async function buildDownloadUrl(platform, arch, version, variant = '', openSSLVersionForTesting = '') {
     let fileName = '';
     const isOpenSSLDependent = semver.lt(version, '1.1.0');
+    const isVolta1 = semver.lt(version, '2.0.0');
     if (variant) {
         fileName = `volta-${version}-${variant}.tar.gz`;
     }
@@ -23158,7 +23159,7 @@ async function buildDownloadUrl(platform, arch, version, variant = '', openSSLVe
                 throw new Error(`your platform ${platform} is not yet supported`);
         }
     }
-    else {
+    else if (isVolta1) {
         switch (platform) {
             case 'darwin':
                 fileName = `volta-${version}-macos${arch === 'arm64' ? '-aarch64' : ''}.tar.gz`;
@@ -23170,6 +23171,24 @@ async function buildDownloadUrl(platform, arch, version, variant = '', openSSLVe
             case 'win32':
                 fileName = `volta-${version}-windows-x86_64.msi`;
                 break;
+            default:
+                throw new Error(`your platform ${platform} is not yet supported`);
+        }
+    }
+    else {
+        switch (platform) {
+            case 'darwin': {
+                fileName = `volta-${version}-macos.tar.gz`;
+                break;
+            }
+            case 'linux': {
+                fileName = `volta-${version}-linux${arch === 'arm64' ? '-arm' : ''}.tar.gz`;
+                break;
+            }
+            case 'win32': {
+                fileName = `volta-${version}-windows-${arch === 'arm64' ? 'arm64' : '-x86_64'}.msi`;
+                break;
+            }
             default:
                 throw new Error(`your platform ${platform} is not yet supported`);
         }

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -93,6 +93,59 @@ describe('buildDownloadUrl', () => {
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"your platform aix is not yet supported"`);
     });
   });
+
+  describe('volta@2.0.0', function () {
+    test('darwin - x64', async function () {
+      expect(await buildDownloadUrl('darwin', 'x64', '2.0.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v2.0.0/volta-2.0.0-macos.tar.gz"`
+      );
+    });
+
+    test('darwin - arm64', async function () {
+      expect(await buildDownloadUrl('darwin', 'arm64', '2.0.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v2.0.0/volta-2.0.0-macos.tar.gz"`
+      );
+    });
+
+    test('linux - x64', async function () {
+      expect(await buildDownloadUrl('linux', 'x64', '2.0.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v2.0.0/volta-2.0.0-linux.tar.gz"`
+      );
+    });
+
+    test('linux - arm64', async function () {
+      expect(await buildDownloadUrl('linux', 'arm64', '2.0.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v2.0.0/volta-2.0.0-linux-arm.tar.gz"`
+      );
+    });
+
+    test('linux with variant input', async function () {
+      expect(
+        await buildDownloadUrl('linux', 'x64', '1.1.0', 'linux-openssl-rhel')
+      ).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v1.1.0/volta-1.1.0-linux-openssl-rhel.tar.gz"`
+      );
+    });
+
+    test('win32 - x64', async function () {
+      expect(await buildDownloadUrl('win32', 'x86-64', '2.0.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v2.0.0/volta-2.0.0-windows-x86_64.msi"`
+      );
+    });
+
+    test('win32 - arm64', async function () {
+      expect(await buildDownloadUrl('win32', 'arm64', '2.0.0')).toMatchInlineSnapshot(
+        `"https://github.com/volta-cli/volta/releases/download/v2.0.0/volta-2.0.0-windows-arm64.msi"`
+      );
+    });
+
+    test('aix', async function () {
+      expect(
+        async () =>
+          await buildDownloadUrl('aix', 'hmm, wat?? (I dont know a valid arch for aix)', '2.0.0')
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"your platform aix is not yet supported"`);
+    });
+  });
 });
 
 describe('getOpenSSLVersion', () => {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -113,6 +113,7 @@ export async function buildDownloadUrl(
   let fileName = '';
 
   const isOpenSSLDependent = semver.lt(version, '1.1.0');
+  const isVolta1 = semver.lt(version, '2.0.0');
 
   if (variant) {
     fileName = `volta-${version}-${variant}.tar.gz`;
@@ -134,7 +135,7 @@ export async function buildDownloadUrl(
       default:
         throw new Error(`your platform ${platform} is not yet supported`);
     }
-  } else {
+  } else if (isVolta1) {
     switch (platform) {
       case 'darwin':
         fileName = `volta-${version}-macos${arch === 'arm64' ? '-aarch64' : ''}.tar.gz`;
@@ -146,6 +147,23 @@ export async function buildDownloadUrl(
       case 'win32':
         fileName = `volta-${version}-windows-x86_64.msi`;
         break;
+      default:
+        throw new Error(`your platform ${platform} is not yet supported`);
+    }
+  } else {
+    switch (platform) {
+      case 'darwin': {
+        fileName = `volta-${version}-macos.tar.gz`;
+        break;
+      }
+      case 'linux': {
+        fileName = `volta-${version}-linux${arch === 'arm64' ? '-arm' : ''}.tar.gz`;
+        break;
+      }
+      case 'win32': {
+        fileName = `volta-${version}-windows-${arch === 'arm64' ? 'arm64' : 'x86_64'}.msi`;
+        break;
+      }
       default:
         throw new Error(`your platform ${platform} is not yet supported`);
     }


### PR DESCRIPTION
Info
-----
- Volta 2.0.0 has some updates to supported architectures that necessitate changing the `buildDownloadUrl` method:
    - On macOS, we now have universal binaries so there is one URL for both `x64` and `arm64`
    - On Linux and Windows, we now also support `arm64` binaries

Changes
-----
- Updated `buildDownloadUrl` to include a new branch for Volta 2.0.0 that handles the new architecture support

Tested
-----
- Updated the `installer.test.ts` file to include a set of tests for Volta 2.0.0