### PR TITLE
Update README.md: Fix registry-url NODE_AUTH_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This action installs [volta](https://volta.sh) by:
 | `yarn-version` | <p>Version Spec of the yarn version to use.  Examples: 1.6.x, 10.15.1, &gt;=10.15.0</p> | `false` | `""` |
 | `package-json-path` | <p>The path to the package.json to update when using an explicit <code>node-version</code> | <code>yarn-version</code> | <code>npm-version</code> override. By default, we will use <code>package.json</code> in the checkout root.</p> | `false` | `""` |
 | `variant` | <p>Specific variant to install. Example: providing the variant "linux-openssl-rhel", which will target installing the volta-${version}-linux-openssl-rhel.tar.gz tarball</p> | `false` | `""` |
-| `registry-url` | <p>Optional registry to set up for auth. Will set the registry in a project level .npmrc file, and set up auth to read in from env.NODE<em>AUTH</em>TOKEN</p> | `false` | `""` |
+| `registry-url` | <p>Optional registry to set up for auth. Will set the registry in a project level .npmrc file, and set up auth to read in from `env.NODE_AUTH_TOKEN`</p> | `false` | `""` |
 | `scope` | <p>Optional scope for authenticating against scoped registries. Will fall back to the repository owner when using the GitHub Packages registry (https://npm.pkg.github.com/).</p> | `false` | `""` |
 | `token` | <p>Used to avoid low rate limiting for cached tool downloads.  Since there's a default, this is typically not supplied by the user.</p> | `false` | `${{ github.token }}` |
 | `always-auth` | <p>Set always-auth in npmrc</p> | `false` | `false` |


### PR DESCRIPTION
The registry-url option sets up auth to read from `env.NODE_AUTH_TOKEN`, but the way the readme was rendered, the underscores surrounding `_AUTH_` were interpreted as italics instead. This small change to the README fixes that.
